### PR TITLE
Extensions like minical requires getOffset* functions to work

### DIFF
--- a/package.js
+++ b/package.js
@@ -25,7 +25,8 @@ Package.onUse(function(api) {
     api.addFiles(getFilesFromFolder(imagesFolder + "imgs_dhx_terrace"), "client");
     api.addFiles(getFilesFromFolder(imagesFolder + "imgs_flat"), "client");
     api.addFiles(getFilesFromFolder(imagesFolder + "imgs_glossy"), "client");
-    api.export("scheduler", "client");
+    api.export(["scheduler", "getOffset", "getOffsetSum",
+  "getOffsetRect", "getAbsoluteTop", "getAbsoluteLeft"], "client");
 });
 
 Package.onTest(function(api) {


### PR DESCRIPTION
Using extensions like minical to display a mini calendar throws an error because it's unable to find the `getOffset` function because only `scheduler` is exported
